### PR TITLE
Make meme master

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -10,5 +10,12 @@
         "706121937713365082"
     ],
     "antiSpamEnabled": true,
-    "antiSpamRole": "839642361298681876"
+    "antiSpamRole": "839642361298681876",
+    "upvotePinEnabled": true,
+    "upvoteThreshold": 5,
+    "upvoteEmojis": ["776486324974649354"],
+    "upvoteWatchlist": [
+        "761128571984674816",
+        "706391702067347456"
+    ]
 }

--- a/src/commands/upvotepin.js
+++ b/src/commands/upvotepin.js
@@ -1,0 +1,61 @@
+const {
+    upvotePinEnabled,
+    upvoteThreshold,
+    upvoteEmojis,
+    upvoteWatchlist
+} = require("../../config.json");
+
+/**
+ * @param {import("discord.js").Message} msg
+ */
+async function execute(msg) {
+    if (msg.content.toLowerCase().startsWith("sbe:upvotepin")) {
+        throw new Error("You are not supposed to call this command");
+    }
+}
+
+/**
+ * Pins messages with enough upvotes.
+ * @param {(
+ *     import("discord.js").PartialMessageReaction |
+ *     import("discord.js").MessageReaction
+ * )} preact
+ */
+async function watcher(preact) {
+    // trust me on these partials
+    const code = preact.emoji.id ?? preact.emoji.name;
+    if (!upvoteEmojis.includes(code)) return;
+    if (!upvoteWatchlist.includes(preact.message.channel.id)) return;
+
+    if (preact.partial) {
+        try {
+            await preact.fetch();
+        } catch {
+            // message probably deleted
+            return;
+        }
+    }
+    /** @type {import("discord.js").MessageReaction} */
+    const react = preact;
+
+    if (react.count < upvoteThreshold) return;
+
+    if (!react.message.pinned) {
+        react.message.pin();
+    }
+}
+
+module.exports = {
+    name: "sbe:upvotepin",
+    execute,
+    load: (client) => {
+        if (upvotePinEnabled) {
+            client.on("messageReactionAdd", watcher);
+        }
+    },
+    unload: (client) => {
+        if (upvotePinEnabled) {
+            client.off("messageReactionAdd", watcher);
+        }
+    }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,12 @@ const { readdirSync } = require("fs");
 const { token } = require("../config.json");
 
 const client = new Client({
-    intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES],
+    intents: [
+        Intents.FLAGS.GUILDS,
+        Intents.FLAGS.GUILD_MESSAGES,
+        Intents.FLAGS.GUILD_MESSAGE_REACTIONS
+    ],
+    partials: ["MESSAGE", "REACTION"],
     allowedMentions: {
         repliedUser: true
     }


### PR DESCRIPTION
Makes shapebot pin messages in `#shapez-memes` or `#memes` with at least 5 `:upvote:`s. **It will not unpin messages.**

Config settings are added for:
* toggling the feature
* how many upvotes are needed
* the emojis that count as upvotes (any one emoji must reach the threshold, not their sum)
* the channels where this feature applies

Note only the `:upvote:` emoji works. I considered allowing all emojis, but I feel it'd be too hard to account for non-"I like this" emojis, even with a blacklist. Besides, almost all current pinned memes used `:upvote:`s.

Partials are used, don't think anything breaks.